### PR TITLE
Group nodes by type in TrafficVisualization

### DIFF
--- a/app/ui/traffic/TrafficVisualization.tsx
+++ b/app/ui/traffic/TrafficVisualization.tsx
@@ -58,12 +58,29 @@ const getLayoutedElements = (
   edges: Edge[],
   direction = "LR"
 ) => {
-  // Custom layout logic here
-  let id = 0;
-  const layoutedNodes = nodes.map((node) => ({
-    ...node,
-    position: { x: (id++ % 5) * 250, y: Math.floor(id / 5) * 100 },
-  }));
+  // Group nodes by their type
+  const groupedNodes = nodes.reduce((acc, node) => {
+    acc[node.type] = acc[node.type] || [];
+    acc[node.type].push(node);
+    return acc;
+  }, {});
+
+  // Position nodes of the same type closer together
+  let yPos = 0;
+  let xPos = 0;
+  const layoutedNodes = [];
+  Object.keys(groupedNodes).forEach((type, typeIndex) => {
+    groupedNodes[type].forEach((node, index) => {
+      layoutedNodes.push({
+        ...node,
+        position: { x: xPos, y: yPos },
+      });
+      yPos += 100; // Increment y position for the next node in the same group
+    });
+    xPos += 250; // Increment x position for the next group
+    yPos = 0; // Reset y position for the next group
+  });
+
   return { nodes: layoutedNodes, edges };
 };
 


### PR DESCRIPTION
Related to #26

Updates the `getLayoutedElements` function in `TrafficVisualization.tsx` to group nodes by their `Node.type` and position them closer together based on their grouping.

- **Grouping Logic**: Implements logic within `getLayoutedElements` to group nodes by their `Node.type`. This is achieved by reducing the nodes array into an object where each key represents a node type and its value is an array of nodes of that type.
- **Positioning Logic**: Adjusts the positioning of nodes so that nodes of the same `Node.type` are positioned closer together. This is done by iterating over each group and setting the `x` and `y` positions such that each group is placed in a new column (`x` position) and nodes within the same group are stacked vertically (`y` position).


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/screwyforcepush/AIMM/issues/26?shareId=73ccf5ee-1722-4304-925c-8482252fd442).