### PR TITLE
Fix OpenAI API deprecation issue

### DIFF
--- a/app/api/openai-assistant/route.ts
+++ b/app/api/openai-assistant/route.ts
@@ -16,18 +16,30 @@ const handler = traceable(async (request: NextRequest) => {
     const openai = new OpenAI();
 
     if (!newMessage.threadId) {
-        const thread = await openai.beta.threads.create();
+        const thread = await openai.beta.threads.create({
+            headers: {
+                'OpenAI-Beta': 'assistants=v2'
+            }
+        });
         newMessage.threadId = thread.id;
     }
 
     await openai.beta.threads.messages.create(newMessage.threadId, {
         role: "user",
         content: newMessage.content
+    }, {
+        headers: {
+            'OpenAI-Beta': 'assistants=v2'
+        }
     });
 
     const run = await openai.beta.threads.runs.createAndStream(newMessage.threadId, {
         assistant_id: newMessage.assistantId,
         stream: true
+    }, {
+        headers: {
+            'OpenAI-Beta': 'assistants=v2'
+        }
     });
 
     const stream = run.toReadableStream();
@@ -61,6 +73,11 @@ export const GET = async (request:NextRequest) => {
     const threadMessages = await openai.beta.threads.messages.list(
         threadId,
         {limit: parseInt(messageLimit)},
+        {
+            headers: {
+                'OpenAI-Beta': 'assistants=v2'
+            }
+        }
     );
 
     // only transmit the data that we need


### PR DESCRIPTION
Fixes #34

Update `app/api/openai-assistant/route.ts` to use the v2 Assistants API by setting the required header.

* Add the header 'OpenAI-Beta: assistants=v2' to the `fetch` request in the `handler` function.
* Add the header 'OpenAI-Beta: assistants=v2' to the `fetch` request in the `GET` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/screwyforcepush/AIMM/pull/35?shareId=25edfe64-e74e-445b-84ef-d4cb89364917).